### PR TITLE
feat: home 페이지 레이아웃

### DIFF
--- a/src/apis/getUser.ts
+++ b/src/apis/getUser.ts
@@ -1,0 +1,15 @@
+export interface UserInfo {
+  account: string;
+  email: string;
+  password: string;
+  nickname: string;
+}
+
+export const getUser = async (): Promise<UserInfo> => {
+  return {
+    account: 'hong',
+    email: 'hong1@email.com',
+    password: '12345!',
+    nickname: 'hong1'
+  }
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,8 +1,10 @@
-import BaseFrame from '@/shared/@common/ui/baseFrame/BaseFrame';
+import HomePage from '@/views/HomePage';
 import React from 'react';
 
-const HomePage = () => {
-  return <BaseFrame>홈</BaseFrame>;
+const Page = () => {
+  return (
+    <HomePage />
+  )
 };
 
-export default HomePage;
+export default Page;

--- a/src/globals.css
+++ b/src/globals.css
@@ -68,6 +68,13 @@
     font-family: inherit;
     font-size: inherit;
   }
+  .hidden-scrollbar {
+    -ms-overflow-style: none; 
+    scrollbar-width: none; 
+  }
+  .hidden-scrollbar::-webkit-scrollbar {
+    display: none; 
+  }
 }
 
 @layer components {

--- a/src/shared/@common/ui/baseFrame/BaseFrame.tsx
+++ b/src/shared/@common/ui/baseFrame/BaseFrame.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import BottomMenuBar from '../bottomMenu/BottomMenuBar';
-import Header from '../Header/Header';
-import CancelSaveHeader from '../Header/CancelSaveHeader';
+import Header from '../header/Header';
+import CancelSaveHeader from '../header/CancelSaveHeader';
 
 interface FrameProps {
   children?: React.ReactNode;

--- a/src/shared/@common/ui/bottomMenu/BottomButton.tsx
+++ b/src/shared/@common/ui/bottomMenu/BottomButton.tsx
@@ -3,12 +3,13 @@ import React, { FC, SVGProps } from 'react';
 interface IconProps {
   Icon: FC<SVGProps<SVGElement>>;
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
 }
 
-function BottomButton({ Icon, onClick }: IconProps) {
+function BottomButton({ Icon, onClick, className }: IconProps) {
   return (
     <button onClick={onClick} className="flex justify-center items-center">
-      <Icon className={'fill-gray8 hover:fill-primary'} />
+      <Icon className={`fill-gray8 hover:fill-primary ${className}`} />
     </button>
   );
 }

--- a/src/shared/@common/ui/bottomMenu/BottomMenuBar.tsx
+++ b/src/shared/@common/ui/bottomMenu/BottomMenuBar.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { homeIcon, commIcon, infoIcon, libIcon, plusIcon } from '../../../../../public/icons/bottomMenuBar';
 import BottomButton from './BottomButton';
+import { useState } from 'react';
 
 const BUTTON_PROPS = [
   {
@@ -28,6 +29,13 @@ const BUTTON_PROPS = [
 
 function BottomMenuBar() {
   const router = useRouter();
+  const pathname = usePathname();
+  const [activeUrl, setActiveUrl] = useState<string>(pathname);
+
+  const handleButtonClick = (url: string) => {
+    setActiveUrl(url);
+    router.push(url);
+  }
 
   return (
     <div className="w-[390px] h-[65px] bg-white flex justify-between items-center px-[1.5625rem] fixed bottom-0 z-10">
@@ -35,10 +43,11 @@ function BottomMenuBar() {
         <BottomButton
           key={url}
           Icon={Icon}
-          onClick={e => {
-            e.preventDefault;
-            router.push(url);
+          onClick={(e) => {
+            e.preventDefault();
+            handleButtonClick(url);
           }}
+          className={activeUrl === url ? 'fill-primary' : 'fill-gray8'}
         />
       ))}
     </div>

--- a/src/shared/comm/CardDeckItem.tsx
+++ b/src/shared/comm/CardDeckItem.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import RatingStars from '../@common/ui/ratingStars/RatingStars';
+
+
+interface CardDeckItemProps {
+  deckTitle: string;
+  count: number;
+  constructor: string;
+}
+
+const CardDeckItem = ({ deckTitle, count, constructor }: CardDeckItemProps) => {
+  return (
+    <div className="bg-white border border-gray border-1 min-w-[12.0625rem] rounded-[0.5rem] p-[0.75rem] shadow flex flex-col h-[9.125rem] justify-between">
+      <div className="flex flex-col gap-[0.5rem]">
+        <p className="text-20 font-bold text-text_primary">{deckTitle}</p>
+        <div className="bg-primary rounded-[0.3125rem] w-[3.8125rem] text-12 px-[0.625rem] py-[0.3125rem] text-white flex justify-center items-center ">
+          <p>{count} 단어</p>
+        </div>
+      </div>
+      <div className="flex justify-between items-center">
+        <p className="text-text_secondary h-4 text-12">{constructor}</p>
+        <RatingStars />
+      </div>
+    </div>
+  );
+};
+
+export default CardDeckItem;

--- a/src/shared/comm/CardDeckList.tsx
+++ b/src/shared/comm/CardDeckList.tsx
@@ -1,15 +1,17 @@
 import React, { useRef, useState } from 'react';
 import Button from '../@common/ui/button/Button';
 import CardDeckItem from './CardDeckItem';
+import Link from 'next/link';
 
 interface CardDeckListProps {
   title: string;
   deckTitle: string;
   count: number;
   constructor: string;
+  moreLink: string;
 }
 
-const CardDeckList = ({ title, deckTitle, count, constructor }: CardDeckListProps) => {
+const CardDeckList = ({ title, deckTitle, count, constructor, moreLink }: CardDeckListProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [startX, setStartX] = useState(0);
@@ -42,10 +44,12 @@ const CardDeckList = ({ title, deckTitle, count, constructor }: CardDeckListProp
   };
 
   return (
-    <div className="flex flex-col gap-[0.75rem]">
+    <div className="flex flex-col gap-[0.75rem] w-full">
       <div className="flex justify-between font-bold">
         <p className="text-20 text-text_primary">{title}</p>
-        <Button type="xs-more">더보기</Button>
+        <Link href={moreLink}>
+          <Button type="xs-more">더보기</Button>
+        </Link>
       </div>
       <div
         className="flex gap-[0.75rem] overflow-hidden w-[22.875rem] hidden-scrollbar cursor-grab active:cursor-grabbing"

--- a/src/shared/comm/CardDeckList.tsx
+++ b/src/shared/comm/CardDeckList.tsx
@@ -1,0 +1,66 @@
+import React, { useRef, useState } from 'react';
+import Button from '../@common/ui/button/Button';
+import CardDeckItem from './CardDeckItem';
+
+interface CardDeckListProps {
+  title: string;
+  deckTitle: string;
+  count: number;
+  constructor: string;
+}
+
+const CardDeckList = ({ title, deckTitle, count, constructor }: CardDeckListProps) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (scrollContainerRef.current) {
+      setIsDragging(true);
+      setStartX(e.pageX - scrollContainerRef.current.offsetLeft);
+      setScrollLeft(scrollContainerRef.current.scrollLeft);
+    }
+  };
+
+  const handleMouseLeave = () => {
+    setIsDragging(false);
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    e.preventDefault();
+    if (scrollContainerRef.current) {
+      const x = e.pageX - scrollContainerRef.current.offsetLeft;
+      const move = (x - startX) * 2;
+      scrollContainerRef.current.scrollLeft = scrollLeft - move;
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-[0.75rem]">
+      <div className="flex justify-between font-bold">
+        <p className="text-20 text-text_primary">{title}</p>
+        <Button type="xs-more">더보기</Button>
+      </div>
+      <div
+        className="flex gap-[0.75rem] overflow-hidden w-[22.875rem] hidden-scrollbar cursor-grab active:cursor-grabbing"
+        ref={scrollContainerRef}
+        onMouseDown={handleMouseDown}
+        onMouseLeave={handleMouseLeave}
+        onMouseUp={handleMouseUp}
+        onMouseMove={handleMouseMove}
+      >
+        <CardDeckItem deckTitle={deckTitle} count={count} constructor={constructor} />
+        <CardDeckItem deckTitle={deckTitle} count={count} constructor={constructor} />
+        <CardDeckItem deckTitle={deckTitle} count={count} constructor={constructor} />
+      </div>
+    </div>
+  );
+};
+
+export default CardDeckList;

--- a/src/views/HomePage/index.tsx
+++ b/src/views/HomePage/index.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import React from 'react';
+import BaseFrame from '@/shared/@common/ui/baseFrame/BaseFrame';
+import Button from '@/shared/@common/ui/button/Button';
+import Link from 'next/link';
+import CardDeckList from '@/shared/comm/CardDeckList';
+
+const HomePage = () => {
+
+  return (
+    <BaseFrame>
+    <div className='py-[20px] flex flex-col gap-[30px] items-center'>
+      <div className='flex flex-col p-[16px] w-[366px] h-[184px] bg-[#ECE3FF] rounded-[8px] items-center justify-center gap-5'>
+        <div>
+          <p className='font-bold text-20'>{}님과 {}일 동안 함께하고 있어요!</p>
+          <p className='font-regular'>성장을 위해 꾸준히 학습해보세요!</p>
+        </div>
+        <Button type="m-more">
+          오늘 학습하러 가기
+        </Button>
+      </div>
+      <div>
+        <CardDeckList title="카드뭉치" constructor="휘연" count={20} deckTitle="Job SecuritySec" />
+      </div>
+      <div>
+        <CardDeckList title="폴더" constructor="휘연" count={20} deckTitle="Job SecuritySec" />
+      </div>
+      <div>
+        <CardDeckList title="다른 사용자와 유사한 카드뭉치" constructor="휘연" count={20} deckTitle="Job SecuritySec" />
+      </div>
+    </div>
+    </BaseFrame>
+  )
+}
+
+export default HomePage

--- a/src/views/HomePage/index.tsx
+++ b/src/views/HomePage/index.tsx
@@ -3,33 +3,50 @@
 import React from 'react';
 import BaseFrame from '@/shared/@common/ui/baseFrame/BaseFrame';
 import Button from '@/shared/@common/ui/button/Button';
-import Link from 'next/link';
 import CardDeckList from '@/shared/comm/CardDeckList';
 
 const HomePage = () => {
 
   return (
     <BaseFrame>
-    <div className='py-[20px] flex flex-col gap-[30px] items-center'>
-      <div className='flex flex-col p-[16px] w-[366px] h-[184px] bg-[#ECE3FF] rounded-[8px] items-center justify-center gap-5'>
-        <div>
-          <p className='font-bold text-20'>{}님과 {}일 동안 함께하고 있어요!</p>
-          <p className='font-regular'>성장을 위해 꾸준히 학습해보세요!</p>
+      <div className='py-[20px] flex flex-col gap-[30px] items-center'>
+        <div className='flex flex-col p-[16px] w-[366px] h-[184px] bg-[#ECE3FF] rounded-[8px] items-center justify-center gap-5'>
+          <div>
+            <p className='font-bold text-20'>{}님과 {}일 동안 함께하고 있어요!</p>
+            <p className='font-regular'>성장을 위해 꾸준히 학습해보세요!</p>
+          </div>
+          <Button type="m-more">
+            오늘 학습하러 가기
+          </Button>
         </div>
-        <Button type="m-more">
-          오늘 학습하러 가기
-        </Button>
+        <div className='w-full'>
+          <CardDeckList 
+            title="카드뭉치" 
+            constructor="휘연" 
+            count={20} 
+            deckTitle="Job SecuritySec" 
+            moreLink='/lib/cardDecks'
+          />
+        </div>
+        <div className='w-full'>
+          <CardDeckList 
+            title="폴더" 
+            constructor="휘연" 
+            count={20} 
+            deckTitle="Job SecuritySec" 
+            moreLink='/lib/folders'
+          />
+        </div>
+        <div className='w-full'>
+          <CardDeckList 
+            title="다른 사용자와 유사한 카드뭉치" 
+            constructor="휘연" 
+            count={20} 
+            deckTitle="Job SecuritySec" 
+            moreLink='/'
+          />
+        </div>
       </div>
-      <div>
-        <CardDeckList title="카드뭉치" constructor="휘연" count={20} deckTitle="Job SecuritySec" />
-      </div>
-      <div>
-        <CardDeckList title="폴더" constructor="휘연" count={20} deckTitle="Job SecuritySec" />
-      </div>
-      <div>
-        <CardDeckList title="다른 사용자와 유사한 카드뭉치" constructor="휘연" count={20} deckTitle="Job SecuritySec" />
-      </div>
-    </div>
     </BaseFrame>
   )
 }

--- a/src/views/LandingPage/index.tsx
+++ b/src/views/LandingPage/index.tsx
@@ -7,6 +7,12 @@ import Link from 'next/link';
 
 const LandingPage = () => {
 
+  //TODO:
+  const handleKakaoLogin = async () => {
+    console.log("작동");
+  };
+  
+
   return (
     <main className="flex flex-col items-center min-h-screen">
       <div className="container bg-primary flex-grow py-[40px] items-center justify-center flex flex-col gap-[12px]">
@@ -19,12 +25,25 @@ const LandingPage = () => {
             priority
           />
         </div>
-        <div className='space-y-5'>
+        <div className='space-y-3'>
           <Link href="/signup">
             <Button type="xl-full-white">
               회원가입
             </Button>
           </Link>
+          <div
+            className="flex justify-center w-[350px] h-[56px] bg-[#fae101] items-center cursor-pointer rounded-md"
+            onClick={handleKakaoLogin}
+          >
+            <Image 
+              src="/icons/kakao.svg"
+              alt="kakao" 
+              width={23} 
+              height={23} 
+              className="w-[23px] mr-5" 
+            />
+            카카오로 로그인하기
+          </div>
           <Link href="/login">
             <Button type="xl-full-primary">
               로그인

--- a/src/views/MyPage/MyPage/index.tsx
+++ b/src/views/MyPage/MyPage/index.tsx
@@ -9,12 +9,15 @@ import Modal from '@/shared/@common/ui/modal';
 import { useState, useEffect } from 'react';
 import Input from '@/shared/@common/ui/input/Input';
 import validInput from '@/shared/@common/utils/validInput';
+import { getUser, UserInfo } from '@/apis/getUser';
 
 const MyPage = () => {
-  // TODO: userId, nickname, email, point
-  const userId = 'vocca';
-  const userNickName = 'vocca1';
-  const userEmail = 'vocca@email.com';
+  const [user, setUser] = useState<UserInfo>({
+    account: '',
+    email: '',
+    password: '',
+    nickname: ''
+  });
   const userPoint = '125';
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -40,6 +43,15 @@ const MyPage = () => {
   });
 
   useEffect(() => {
+    const fetchUser = async () => {
+      const userData = await getUser();
+      setUser(userData);
+    };
+
+    fetchUser();
+  }, []);
+
+  useEffect(() => {
     if (!isModalOpen) {
       setInput({
         account: '',
@@ -56,13 +68,12 @@ const MyPage = () => {
 
   const handleChangeInput = (
     e: React.ChangeEvent<HTMLInputElement>,
-    path: string,
     name: string,
-    inputValue: string,
     currentPassword?: string,
   ) => {
-    if (e.target) setInput(state => ({ ...state, [name]: inputValue }));
-    setIsValid(state => ({ ...state, [name]: validInput(path, name, inputValue, currentPassword || '') }));
+    const inputValue = e.target.value;
+    setInput(state => ({ ...state, [name]: inputValue }));
+    setIsValid(state => ({ ...state, [name]: validInput(name, inputValue, currentPassword || '') }));
   };
 
   const handleOpenModal = (type: string) => {
@@ -94,7 +105,13 @@ const MyPage = () => {
       const data = { [modalType]: input[modalType] };
       console.log('Submit data:', data);
 
-      if (modalType === 'email') setEmailSent(true);
+      if (modalType === 'email') {
+        setUser((prevUser: UserInfo) => ({ ...prevUser, email: input.email }));
+        setEmailSent(true);
+      } else if (modalType === 'nickname') {
+        setUser((prevUser: UserInfo) => ({ ...prevUser, nickname: input.nickname }));
+        setIsModalOpen(false); 
+      }
     }
   };
 
@@ -118,17 +135,17 @@ const MyPage = () => {
         return (
           <div>
             <p className="font-medium pb-[15px]">닉네임 변경</p>
-            <form id="nickname" >
+            <form id="nickname">
               <Input
-                name={input.name}
+                name={inputProps.nickname.name}
                 value={input.nickname}
                 label={inputProps.nickname.label}
                 type={inputProps.nickname.type}
-                placeholder={userNickName} 
-                onChange={e => handleChangeInput(e, inputProps.nickname.path, inputProps.nickname.name, e.target.value)}
-                path={inputProps.nickname.path}
+                placeholder={user.nickname}
+                onChange={e => handleChangeInput(e, inputProps.nickname.name)}
                 isValid={isValid.nickname}
-                errormessage={inputProps.nickname.errormessage}
+                errorMessage={inputProps.nickname.errorMessage}
+                width='350px'
               />
             </form>
           </div>
@@ -146,13 +163,13 @@ const MyPage = () => {
                   value={input.email}
                   label={inputProps.email.label}
                   type={inputProps.email.type}
-                  placeholder={userEmail}
-                  onChange={e => handleChangeInput(e, inputProps.email.path, inputProps.email.name, e.target.value)}
-                  path={inputProps.email.path}
+                  placeholder={user.email}
+                  onChange={e => handleChangeInput(e, inputProps.email.name)}
                   isValid={isValid.email}
-                  errormessage={inputProps.email.errormessage}
+                  errorMessage={inputProps.email.errorMessage}
+                  width='350px'
                 />
-            </form>
+              </form>
             )}
           </div>
         );
@@ -162,38 +179,38 @@ const MyPage = () => {
             <p className="font-medium pb-[15px]">비밀번호 변경</p>
             <form id="password" className="flex flex-col gap-[10px]">
             <Input
-                name={inputProps.password.name}
-                value={input.password}
-                label="현재 비밀번호" 
-                type="password"
-                placeholder="현재 비밀번호를 입력하세요"
-                onChange={e => handleChangeInput(e, inputProps.password.path, inputProps.password.name, e.target.value)}
-                path={inputProps.password.path}
-                isValid={isValid.password}
-                errormessage={inputProps.password.errormessage}
-              />
-              <Input
-                name="new_password"
-                value={input.new_password}
-                label="새 비밀번호"
-                type="password"
-                placeholder="새 비밀번호를 입력하세요"
-                onChange={e => handleChangeInput(e, inputProps.password.path, 'new_password', e.target.value)}
-                path={inputProps.password.path}
-                isValid={isValid.new_password}
-                errormessage="새 비밀번호를 입력하세요"
-              />
-              <Input
-                name="check_new_password"
-                value={input.check_new_password}
-                label="새 비밀번호 확인"
-                type="password"
-                placeholder="새 비밀번호를 다시 입력하세요"
-                onChange={e => handleChangeInput(e, inputProps.password.path, 'check_new_password', e.target.value, input.new_password)}
-                path={inputProps.password.path}
-                isValid={isValid.check_new_password}
-                errormessage="비밀번호가 일치하지 않습니다"
-              />
+              name={inputProps.password.name}
+              value={input.password}
+              label="현재 비밀번호" 
+              type="password"
+              placeholder="현재 비밀번호를 입력하세요"
+              onChange={e => handleChangeInput(e, inputProps.password.name)}
+              isValid={isValid.password}
+              errorMessage={inputProps.password.errorMessage}
+              width='350px'
+            />
+            <Input
+              name="new_password"
+              value={input.new_password}
+              label="새 비밀번호"
+              type="password"
+              placeholder="새 비밀번호를 입력하세요"
+              onChange={e => handleChangeInput(e, 'new_password')}
+              isValid={isValid.new_password}
+              errorMessage="새 비밀번호를 입력하세요"
+              width='350px'
+            />
+            <Input
+              name="check_new_password"
+              value={input.check_new_password}
+              label="새 비밀번호 확인"
+              type="password"
+              placeholder="새 비밀번호를 다시 입력하세요"
+              onChange={e => handleChangeInput(e, 'check_new_password', input.new_password)}
+              isValid={isValid.check_new_password}
+              errorMessage="비밀번호가 일치하지 않습니다"
+              width='350px'
+            />
             </form>
           </div>
         );
@@ -208,17 +225,17 @@ const MyPage = () => {
         <div className="flex flex-col flex-grow gap-[30px] items-center">
           <div className='flex flex-col space-y-1'>
             <ProfileAvatar />
-            <p className="font-medium text-center">{userId}</p>
+            <p className="font-medium text-center">{user.account}</p>
           </div>
           <div className='flex flex-col bg-white pt-[15px] border border-grayc rounded-[15px]'>
             <div className='w-[350px] pb-[10px] px-[15px] border-b border-grayc'>
               <p className='text-14'>아이디</p>
-              <p className='text-gray6 text-14'>{userId}</p>
+              <p className='text-gray6 text-14'>{user.account}</p>
             </div>
             <div className='w-[350px] p-[10px] px-[15px] border-b border-grayc flex justify-between'>
               <div className='flex flex-col'>
                 <p className='text-14'>닉네임</p>
-                <p className='text-gray6 text-14'>{userNickName}</p>
+                <p className='text-gray6 text-14'>{user.nickname}</p>
               </div>
               <div 
                 className='relative flex items-center cursor-pointer'
@@ -236,7 +253,7 @@ const MyPage = () => {
             <div className='w-[350px] p-[10px] px-[15px] border-b border-grayc flex justify-between'>
               <div className='flex flex-col'>
                 <p className='text-14'>이메일</p>
-                <p className='text-gray6 text-14'>{userEmail}</p>
+                <p className='text-gray6 text-14'>{user.email}</p>
               </div> 
               <div 
                 className='relative flex items-center cursor-pointer'

--- a/src/views/MyPage/ProfileEditPage/index.tsx
+++ b/src/views/MyPage/ProfileEditPage/index.tsx
@@ -56,7 +56,7 @@ const ProfileEditPage = () => {
   const handleSaveClick = () => {
     if (selectedAvatar !== null) {
       localStorage.setItem('avatarUrl', avatars[selectedAvatar]);
-      router.push('/mypage');
+      router.push('/info');
     }
   };
 

--- a/src/views/MyPage/SettingsPage/index.tsx
+++ b/src/views/MyPage/SettingsPage/index.tsx
@@ -5,15 +5,54 @@ import Modal from '@/shared/@common/ui/modal';
 import Toggle from '@/shared/@common/ui/toggle/Toggle';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Button from '@/shared/@common/ui/button/Button';
+import Input from '@/shared/@common/ui/input/Input';
+import { SIGN_UP_INPUT_PROPS } from '@/shared/@common/constants/input';
+import validInput from '@/shared/@common/utils/validInput';
 
 
 const SettingsPage = () => {
   const router = useRouter();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalContent, setModalContent] = useState<React.ReactNode>(null);
+  const [isValid, setIsValid] = useState<ValidationState>({
+    account: false,
+    nickname: false,
+    password: true,
+    check_password: false,
+    email: false,
+  });
+  const [input, setInput] = useState<InputState>({
+    account: '',
+    nickname: '',
+    password: '',
+    check_password: '',
+    email: '',
+  });
+
+  useEffect(() => {
+    if (!isModalOpen) {
+      setInput({
+        account: '',
+        nickname: '',
+        password: '',
+        check_password: '',
+        email: '',
+      });
+    }
+  }, [isModalOpen]);
+
+  const handleChangeInput = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    name: string,
+    currentPassword?: string,
+  ) => {
+    const inputValue = e.target.value;
+    setInput(state => ({ ...state, [name]: inputValue }));
+    setIsValid(state => ({ ...state, [name]: validInput(name, inputValue, currentPassword || '') }));
+  };
 
   const handleOpenModal = (content: React.ReactNode) => {
     setModalContent(content);
@@ -29,6 +68,11 @@ const SettingsPage = () => {
   const handleConfirm = () => {
     router.push('/accountdelete');
   };
+
+  const inputProps = SIGN_UP_INPUT_PROPS.reduce((fields, prop) => {
+    fields[prop.name] = prop;
+    return fields;
+  }, {} as Record<string, typeof SIGN_UP_INPUT_PROPS[0]>);
   
 
   return (
@@ -79,8 +123,18 @@ const SettingsPage = () => {
               onClick={() => handleOpenModal(
                 <div>
                   <p className="font-medium">비밀번호 입력</p>
-                  <p className="text-14 text-gray6">본인확인을 위해 비밀번호를 입력하세요.</p>
-                  TODO: 인풋
+                  <p className="text-14 text-gray6 pb-[15px]">본인확인을 위해 비밀번호를 입력하세요.</p>
+                  <Input
+                    name={inputProps.password.name}
+                    value={input.password}
+                    label="현재 비밀번호" 
+                    type="password"
+                    placeholder="현재 비밀번호를 입력하세요"
+                    onChange={e => handleChangeInput(e, inputProps.password.name, e.target.value)}
+                    isValid={isValid.password}
+                    errorMessage={inputProps.password.errorMessage}
+                    width='350px'
+                  />
                 </div>
               )}
             >

--- a/src/views/auth/EmailTemplate/index.tsx
+++ b/src/views/auth/EmailTemplate/index.tsx
@@ -1,0 +1,79 @@
+interface Props {
+  userId: string;
+  loginLink: string;
+}
+
+const emailTemplate = ({ userId, loginLink }: Props) => {
+  return `
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Email Template</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+        background-color: #f4f4f4;
+      }
+      .email-container {
+        max-width: 600px;
+        margin: 0 auto;
+        background-color: #ffffff;
+        padding: 20px;
+        border: 1px solid #dddddd;
+      }
+      .header {
+        text-align: center;
+        padding: 10px 0;
+        background-color: #007bff;
+        color: #ffffff;
+      }
+      .header h1 {
+        margin: 0;
+      }
+      .content {
+        padding: 20px;
+      }
+      .content p {
+        margin: 0 0 10px;
+      }
+      .footer {
+        text-align: center;
+        padding: 10px 0;
+        background-color: #eeeeee;
+        color: #666666;
+      }
+      .button {
+        display: inline-block;
+        padding: 10px 20px;
+        font-size: 16px;
+        color: #ffffff;
+        background-color: #007bff;
+        text-decoration: none;
+        border-radius: 5px;
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="email-container">
+      <div class="header">
+        <h1>Company Name</h1>
+      </div>
+      <div class="content">
+        <h2>Hello,</h2>
+        <p>회원님의 아이디는 <strong>${userId}</strong> 입니다.</p>
+        <p>로그인을 위해 아래 버튼을 클릭하세요:</p>
+        <a href="${loginLink}" class="button">로그인</a>
+      </div>
+      <div class="footer">
+        <p>&copy; 2024 Company Name. All rights reserved.</p>
+      </div>
+    </div>
+  </body>
+  </html>
+  `;
+};

--- a/src/views/auth/LoginPage/index.tsx
+++ b/src/views/auth/LoginPage/index.tsx
@@ -49,13 +49,12 @@ const LoginPage = () => {
 
   const handleChangeInput = (
     e: React.ChangeEvent<HTMLInputElement>,
-    path: string,
     name: string,
     inputValue: string,
     currentPassword?: string,
   ) => {
     if (e.target) setInput(state => ({ ...state, [name]: inputValue }));
-    setIsValid(state => ({ ...state, [name]: validInput(path, name, inputValue, currentPassword || '') }));
+    setIsValid(state => ({ ...state, [name]: validInput( name, inputValue, currentPassword || '') }));
   };
 
   const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -120,11 +119,11 @@ const LoginPage = () => {
               label={inputProps.email.label}
               type={inputProps.email.type}
               placeholder={inputProps.email.placeholder}
-              onChange={e => handleChangeInput(e, inputProps.email.path, inputProps.email.name, e.target.value)}
-              path={inputProps.email.path}
+              onChange={e => handleChangeInput(e, inputProps.email.name, e.target.value)}
               isValid={isValid.email}
               // errormessage={inputProps.email.errormessage}
-              errormessage={input.email && !isValid.email ? inputProps.email.errormessage : ''}
+              errorMessage={input.email && !isValid.email ? inputProps.email.errorMessage : ''}
+              width='350px'
             />
           </form>
         )}
@@ -162,10 +161,10 @@ const LoginPage = () => {
                 label="아이디 또는 이메일"
                 type={inputProps.account.type}
                 placeholder="아이디 또는 이메일을 입력해주세요."
-                onChange={e => handleChangeInput(e, inputProps.account.path, inputProps.account.name, e.target.value)}
-                path={inputProps.account.path}
+                onChange={e => handleChangeInput(e, inputProps.account.name, e.target.value)}
                 isValid={isValid.account}
-                errormessage={inputProps.account.errormessage}
+                errorMessage={inputProps.account.errorMessage}
+                width='350px'
               />
               <Input
                 name={inputProps.password.name}
@@ -173,10 +172,10 @@ const LoginPage = () => {
                 label={inputProps.password.label}
                 type={inputProps.password.type}
                 placeholder={inputProps.password.placeholder}
-                onChange={e => handleChangeInput(e, inputProps.password.path, inputProps.password.name, e.target.value)}
-                path={inputProps.password.path}
+                onChange={e => handleChangeInput(e, inputProps.password.name, e.target.value)}
                 isValid={isValid.password}
-                errormessage={inputProps.password.errormessage}
+                errorMessage={inputProps.password.errorMessage}
+                width='350px'
               />
             </form>
           </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #36 

## 📝작업 내용

> - home 레이아웃 구현 시  호범님 comm/CardDeckList 구조 그대로 옮겨두고 적용했습니다! 
> - 추가로 CardDeckList 컴포넌트에서 
      하단 overflow-x 스크롤 대신 마우스로 드래그 할 수 있도록 수정했습니다. 
      더보기버튼 클릭 시 링크이동을 할 수 있도록  moreLink Props 추가하였습니다. 
     
> - 첫 화면에 카카오로그인 붙이기 
> - info (내 정보페이지) 일단은 프론트에서 수정되도록 함 
> - apis 폴더 생성
      get 조회 데이터만 다 적용해두는 중 (진행중) 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
